### PR TITLE
Add support for .dtsi files used in configs similar to .overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
         "extensions": [
           ".keymap",
           ".overlay",
-          ".dtsi"
+          ".dtsi",
+          ".dts",
+          ".dtso"
         ],
         "configuration": "./language-configuration.json"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         ],
         "extensions": [
           ".keymap",
-          ".overlay"
+          ".overlay",
+          ".dtsi"
         ],
         "configuration": "./language-configuration.json"
       }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
           ".keymap",
           ".overlay",
           ".dtsi",
-          ".dts",
-          ".dtso"
+          ".dts"
         ],
         "configuration": "./language-configuration.json"
       }


### PR DESCRIPTION
A common theme for keeping configs simple is to declare the majority of the kscan, layout-matrix, inside of the dtsi files now. This is done in a lot of examples on the ZMK-CONFIG repo, so I see it fitting to add support for this file as well.